### PR TITLE
fix deadlock in shmget

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -347,7 +347,12 @@ int shmget(key_t key, size_t size, int flags)
 				path_buffer[path_length] = '\0';
 				int shmid = atoi(path_buffer);
 				if (shmid != 0) {
-					int idx = ashv_read_remote_segment(shmid);
+					int idx = ashv_find_local_index(shmid);
+
+					if (idx == -1) {
+						idx = ashv_read_remote_segment(shmid);
+					}
+
 					if (idx != -1) {
 						pthread_mutex_unlock(&mutex);
 						return shmem[idx].id;

--- a/test/deadlock.c
+++ b/test/deadlock.c
@@ -1,0 +1,11 @@
+#include "utils.h"
+
+int main() {
+    key_t SHMEM_KEY = ftok(".", 23);
+
+    int shmid_from_shmget;
+    if ((shmid_from_shmget = shmget(SHMEM_KEY, 30, IPC_CREAT | 0666)) < 0) error_exit("shmget");
+    if ((shmid_from_shmget = shmget(SHMEM_KEY, 30, IPC_CREAT | 0666)) < 0) error_exit("shmget");
+
+    return 0;
+}


### PR DESCRIPTION
`shmget` deadlocks when called more than once in the same process. It [locks the mutex](https://github.com/termux/libandroid-shmem/blob/76da96358213eae725c6df66cc6d1cd08f193327/shmem.c#L333), then [calls `ashv_read_remote_segment`](https://github.com/termux/libandroid-shmem/blob/76da96358213eae725c6df66cc6d1cd08f193327/shmem.c#L350), which asks the background thread in the same process to find a shmid, which in turn [tries to lock the mutex](https://github.com/termux/libandroid-shmem/blob/76da96358213eae725c6df66cc6d1cd08f193327/shmem.c#L200) which is already locked. I included a simple trivial test case that hits the deadlock.

I actually found this in Postgres, noticing that a `CREATE TABLE AS ...` query was never returning, and the process that was executing the query was stuck doing nothing. strace showed one thread stuck reading from a socket, and another stuck waiting on a lock.