### PR TITLE
Do not declare symbols defined in `libc.so`

### DIFF
--- a/exports.txt
+++ b/exports.txt
@@ -1,5 +1,9 @@
 {
 	global:
+		libandroid_shmctl;
+		libandroid_shmget;
+		libandroid_shmat;
+		libandroid_shmdt;
 		shmctl;
 		shmget;
 		shmat;

--- a/shm.h
+++ b/shm.h
@@ -12,15 +12,23 @@ __BEGIN_DECLS
 #endif
 
 /* Shared memory control operations. */
+#undef shmctl
+#define shmctl libandroid_shmctl
 extern int shmctl(int shmid, int cmd, struct shmid_ds* buf);
 
 /* Get shared memory area identifier. */
+#undef shmget
+#define shmget libandroid_shmget
 extern int shmget(key_t key, size_t size, int shmflg);
 
 /* Attach shared memory segment. */
+#undef shmat
+#define shmat libandroid_shmat
 extern void *shmat(int shmid, void const* shmaddr, int shmflg);
 
 /* Detach shared memory segment. */
+#undef shmdt
+#define shmdt libandroid_shmdt
 extern int shmdt(void const* shmaddr);
 
 __END_DECLS

--- a/shmem.c
+++ b/shmem.c
@@ -552,3 +552,13 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 	errno = EINVAL;
 	return -1;
 }
+
+/* Make alias for use with e.g. dlopen() */
+#undef shmctl
+int shmctl(int shmid, int cmd, struct shmid_ds *buf) __attribute__((alias("libandroid_shmctl")));
+#undef shmget
+int shmget(key_t key, size_t size, int flags) __attribute__((alias("libandroid_shmget")));
+#undef shmat
+void* shmat(int shmid, void const* shmaddr, int shmflg) __attribute__((alias("libandroid_shmat")));
+#undef shmdt
+int shmdt(void const* shmaddr) __attribute__((alias("libandroid_shmdt")));


### PR DESCRIPTION
On Android API 26 or later, `shmctl`, `shmdt` and `shmget` are defined
in `libc.so` but are disallowed by SELinux. When a main executable
links against a shared library linking against `libandroid-shmem.so`
which the main executable itself does not link against, then the
definitions in `libandroid-shmem.so` are bypassed but instead the ones
in `libc.so` are used. As a result, when the program calls one of
these three functions, then it fails with "Bad system call".

To avoid this situation, the public header should not directly declare
these symbols. Instead it should declare symbols that are prefixed by
`libandroid_` and `#define` the original symbols as aliases.

Related issue: https://github.com/termux/termux-packages/issues/9560.