### PR TITLE
Include <string.h> in shmem.c for strncpy()

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>


### PR DESCRIPTION
Fixes the below error:

> clang-17: warning: argument unused during compilation: '-shared' [-Wunused-command-line-argument]
> shmem.c:130:2: error: call to undeclared library function 'strncpy' with type 'char *(char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
> strncpy(name_buffer, name, sizeof(name_buffer));