### PR TITLE
shmem: improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 tags
 test/test-*
+test/interactions-shm/test-*

--- a/exports.txt
+++ b/exports.txt
@@ -4,6 +4,8 @@
 		libandroid_shmget;
 		libandroid_shmat;
 		libandroid_shmdt;
+		libandroid_shmat_fd;
+		libandroid_shmdt_fd;
 		shmctl;
 		shmget;
 		shmat;

--- a/shm.h
+++ b/shm.h
@@ -31,6 +31,9 @@ extern void *shmat(int shmid, void const* shmaddr, int shmflg);
 #define shmdt libandroid_shmdt
 extern int shmdt(void const* shmaddr);
 
+extern int libandroid_shmat_fd(int shmid, size_t* out_size);
+extern int libandroid_shmdt_fd(int fd);
+
 __END_DECLS
 
 #endif

--- a/shmem.c
+++ b/shmem.c
@@ -20,14 +20,17 @@
 #define DBG(...) __android_log_print(ANDROID_LOG_INFO, "shmem", __VA_ARGS__)
 #define ASHV_KEY_SYMLINK_PATH _PATH_TMP "ashv_key_%d"
 #define ANDROID_SHMEM_SOCKNAME "/dev/shm/%08x"
+#define ANDROID_SHMEM_GLOBAL_SOCKNAME "/dev/shm/global"
+#define ANDROID_SHMEM_GLOBAL_PROCNAME "global-shmem"
 #define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
 
 // Action numbers
-#define ASHV_RM 0
+#define ASHV_PUT 0
 #define ASHV_GET 1
-#define ASHV_AT 2
-#define ASHV_DT 3
-#define ASHV_UPD 4
+#define ASHV_UPD 2
+#define ASHV_RM 3
+#define ASHV_AT 4
+#define ASHV_DT 5
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -42,6 +45,7 @@ typedef struct {
 	key_t key;
 	int countAttach;
 	pid_t *attachedPids;
+	bool global;
 } shmem_t;
 
 static shmem_t* shmem = NULL;
@@ -52,8 +56,10 @@ static size_t shmem_amount = 0;
 static int ashv_local_socket_id = 0;
 // To handle forks we store which pid the ashv_local_socket_id was
 // created for.
-static pid_t ashv_pid_setup = 0;
+static int ashv_pid_setup = 0;
 static pthread_t ashv_listening_thread_id = 0;
+static int global_sendsock;
+static bool global_conf = false;
 
 static int ancil_send_fd(int sock, int fd)
 {
@@ -209,130 +215,6 @@ static int ashv_write_pids(int sendsock, int idx)
 	return 0;
 }
 
-void android_shmem_attach_pid(int idx, pid_t pid) {
-	int idp = shmem[idx].countAttach;
-	shmem[idx].countAttach++;
-	shmem[idx].attachedPids = realloc(shmem[idx].attachedPids, shmem[idx].countAttach*sizeof(pid_t));
-	shmem[idx].attachedPids[idp] = pid;
-}
-
-void android_shmem_detach_pid(int idx, pid_t pid) {
-	for (int i=0; i<shmem[idx].countAttach; i++) {
-		if (shmem[idx].attachedPids[i] == pid) {
-			shmem[idx].countAttach--;
-			memmove(&shmem[idx].attachedPids[i], &shmem[idx].attachedPids[i+1], (shmem[idx].countAttach-i)*sizeof(pid_t));
-			break;
-		}
-	}
-}
-
-void android_shmem_check_pids(int idx) {
-	for (int i=0; i<shmem[idx].countAttach; i++) {
-		if (kill(shmem[idx].attachedPids[i], 0) != 0) {
-			DBG ("%s: process %d not found, removed from list", __PRETTY_FUNCTION__, shmem[idx].attachedPids[i]);
-			shmem[idx].countAttach--;
-			memmove(&shmem[idx].attachedPids[i], &shmem[idx].attachedPids[i+1], (shmem[idx].countAttach-i)*sizeof(pid_t));
-			i--;
-		}
-	}
-}
-
-void android_shmem_delete(int idx) {
-	if (shmem[idx].descriptor) close(shmem[idx].descriptor);
-	shmem_amount--;
-	memmove(&shmem[idx], &shmem[idx+1], (shmem_amount - idx) * sizeof(shmem_t));
-}
-
-void ashv_delete_segment(int idx) {
-	shmem[idx].markedForDeletion = true;
-	if (shmem[idx].countAttach == 0) {
-		android_shmem_delete(idx);
-	}
-}
-
-#define SOCKET_ASHV_WRITE(type, var) \
-	if (write(sendsock, &shmem[idx].var, sizeof(type)) != sizeof(type)) { \
-		DBG("%s: ERROR: write %s failed: %s", __PRETTY_FUNCTION__, #var, strerror(errno)); \
-		break; \
-	}
-
-#define SOCKET_ASHV_READ(type, var) \
-	if (read(sendsock, &var, sizeof(type)) != sizeof(type)) { \
-		DBG("%s: ERROR: read %s failed: %s", __PRETTY_FUNCTION__, #var, strerror(errno)); \
-		break; \
-	}
-
-static void* ashv_thread_function(void* arg)
-{
-	int sock = *(int*)arg;
-	free(arg);
-	struct sockaddr_un addr;
-	socklen_t len = sizeof(addr);
-	int sendsock;
-	//DBG("%s: thread started", __PRETTY_FUNCTION__);
-	while ((sendsock = accept(sock, (struct sockaddr *)&addr, &len)) != -1) {
-		int shmid;
-		if (recv(sendsock, &shmid, sizeof(shmid), 0) != sizeof(shmid)) {
-			DBG("%s: ERROR: recv() returned not %zu shmid bytes", __PRETTY_FUNCTION__, sizeof(shmid));
-			close(sendsock);
-			continue;
-		}
-		int action;
-		if (recv(sendsock, &action, sizeof(action), 0) != sizeof(action)) {
-			DBG("%s: ERROR: recv() returned not %zu action bytes", __PRETTY_FUNCTION__, sizeof(action));
-			close(sendsock);
-			continue;
-		}
-		pthread_mutex_lock(&mutex);
-		int idx = ashv_find_local_index(shmid);
-		if (idx != -1) {
-			pid_t pid;
-			switch (action) {
-			case ASHV_RM:
-				DBG("%s: action ASHV_RM(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
-				ashv_delete_segment(idx);
-				break;
-			case ASHV_GET:
-				DBG("%s: action ASHV_GET(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
-				SOCKET_ASHV_WRITE(key_t, key)
-				SOCKET_ASHV_WRITE(bool, markedForDeletion)
-				SOCKET_ASHV_WRITE(int, countAttach)
-				if (ancil_send_fd(sendsock, shmem[idx].descriptor) != 0) {
-					DBG("%s: ERROR: ancil_send_fd() failed: %s", __PRETTY_FUNCTION__, strerror(errno));
-				}
-				break;
-			case ASHV_AT:
-				DBG("%s: action ASHV_AT(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
-				SOCKET_ASHV_READ(pid_t, pid)
-				android_shmem_attach_pid(idx, pid);
-				break;
-			case ASHV_DT:
-				DBG("%s: action ASHV_DT(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
-				SOCKET_ASHV_READ(pid_t, pid)
-				android_shmem_detach_pid(idx, pid);
-				break;
-			case ASHV_UPD:
-				DBG("%s: action ASHV_UPD(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
-				SOCKET_ASHV_WRITE(bool, markedForDeletion)
-				android_shmem_check_pids(idx);
-				SOCKET_ASHV_WRITE(int, countAttach)
-				ashv_write_pids(sendsock, idx);
-				break;
-			default:
-				DBG("%s: ERROR: unknown action %d", __PRETTY_FUNCTION__, action);
-				break;
-			}
-		} else {
-			DBG("%s: ERROR: cannot find shmid 0x%x", __PRETTY_FUNCTION__, shmid);
-		}
-		pthread_mutex_unlock(&mutex);
-		close(sendsock);
-		len = sizeof(addr);
-	}
-	DBG ("%s: ERROR: listen() failed, thread stopped", __PRETTY_FUNCTION__);
-	return NULL;
-}
-
 static int ashv_read_pids(int recvsock, int idx)
 {
 	if (shmem[idx].countAttach > 0) {
@@ -352,125 +234,431 @@ static int ashv_read_pids(int recvsock, int idx)
 	return 0;
 }
 
-static int ashv_connect_socket(struct sockaddr_un *addr, int shmid)
+static void android_shmem_attach_pid(int idx, pid_t pid)
 {
-	memset(addr, 0, sizeof(*addr));
-	addr->sun_family = AF_UNIX;
-	sprintf(&addr->sun_path[1], ANDROID_SHMEM_SOCKNAME, ashv_socket_id_from_shmid(shmid));
-	int addrlen = sizeof(addr->sun_family) + strlen(&addr->sun_path[1]) + 1;
+	int idp = shmem[idx].countAttach;
+	shmem[idx].countAttach++;
+	shmem[idx].attachedPids = realloc(shmem[idx].attachedPids, shmem[idx].countAttach*sizeof(pid_t));
+	shmem[idx].attachedPids[idp] = pid;
+}
+
+static void android_shmem_detach_pid(int idx, pid_t pid)
+{
+	for (int i=0; i<shmem[idx].countAttach; i++) {
+		if (shmem[idx].attachedPids[i] == pid) {
+			shmem[idx].countAttach--;
+			memmove(&shmem[idx].attachedPids[i], &shmem[idx].attachedPids[i+1], (shmem[idx].countAttach-i)*sizeof(pid_t));
+			break;
+		}
+	}
+}
+
+static void android_shmem_check_pids(int idx)
+{
+	for (int i=0; i<shmem[idx].countAttach; i++) {
+		if (kill(shmem[idx].attachedPids[i], 0) != 0) {
+			DBG ("%s: process %d not found, removed from list", __PRETTY_FUNCTION__, shmem[idx].attachedPids[i]);
+			shmem[idx].countAttach--;
+			memmove(&shmem[idx].attachedPids[i], &shmem[idx].attachedPids[i+1], (shmem[idx].countAttach-i)*sizeof(pid_t));
+			i--;
+		}
+	}
+}
+
+static void android_shmem_delete(int idx)
+{
+	if (shmem[idx].descriptor) close(shmem[idx].descriptor);
+	shmem_amount--;
+	memmove(&shmem[idx], &shmem[idx+1], (shmem_amount - idx) * sizeof(shmem_t));
+}
+
+static void ashv_delete_segment(int idx)
+{
+	shmem[idx].markedForDeletion = true;
+	if (shmem[idx].countAttach == 0) {
+		android_shmem_delete(idx);
+	}
+}
+
+static void* ashv_thread_function(void* arg)
+{
+	int sock = *(int*)arg;
+	free(arg);
+	struct sockaddr_un addr;
+	socklen_t len = sizeof(addr);
+	int sendsock;
+	DBG("%s: thread started", __PRETTY_FUNCTION__);
+	while ((sendsock = accept(sock, (struct sockaddr *)&addr, &len)) != -1) {
+		int shmid;
+		if (recv(sendsock, &shmid, sizeof(shmid), 0) != sizeof(shmid)) {
+			DBG("%s: ERROR: recv() returned not %zu bytes", __PRETTY_FUNCTION__, sizeof(shmid));
+			close(sendsock);
+			continue;
+		}
+		if (!global_conf) {
+			pthread_mutex_lock(&mutex);
+		}
+		int idx = ashv_find_local_index(shmid);
+		if (idx != -1) {
+			if (write(sendsock, &shmem[idx].key, sizeof(key_t)) != sizeof(key_t)) {
+				DBG("%s: ERROR: write failed: %s", __PRETTY_FUNCTION__, strerror(errno));
+			}
+			if (ancil_send_fd(sendsock, shmem[idx].descriptor) != 0) {
+				DBG("%s: ERROR: ancil_send_fd() failed: %s", __PRETTY_FUNCTION__, strerror(errno));
+			}
+		} else {
+			DBG("%s: ERROR: cannot find shmid 0x%x", __PRETTY_FUNCTION__, shmid);
+		}
+		if (!global_conf) {
+			pthread_mutex_unlock(&mutex);
+		}
+		close(sendsock);
+		len = sizeof(addr);
+	}
+	DBG ("%s: ERROR: listen() failed, thread stopped", __PRETTY_FUNCTION__);
+	return NULL;
+}
+
+static int ashv_put_remote_segment(int shmid)
+{
+	struct sockaddr_un addr;
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	sprintf(&addr.sun_path[1], ANDROID_SHMEM_SOCKNAME, ashv_socket_id_from_shmid(shmid));
+	int addrlen = sizeof(addr.sun_family) + strlen(&addr.sun_path[1]) + 1;
 
 	int recvsock = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (recvsock == -1) {
 		DBG ("%s: cannot create UNIX socket: %s", __PRETTY_FUNCTION__, strerror(errno));
 		return -1;
 	}
-	if (connect(recvsock, (struct sockaddr*)addr, addrlen) != 0) {
-		DBG("%s: Cannot connect to UNIX socket %s: %s, len %d", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno), addrlen);
-		close(recvsock);
-		return -1;
+	if (connect(recvsock, (struct sockaddr*) &addr, addrlen) != 0) {
+		DBG("%s: Cannot connect to UNIX socket %s: %s, len %d", __PRETTY_FUNCTION__, addr.sun_path + 1, strerror(errno), addrlen);
+		goto error_close;
 	}
 
-	return recvsock;
-}
-
-static int ashv_send_shmid_action(int recvsock, struct sockaddr_un *addr, int shmid, int action)
-{
 	if (send(recvsock, &shmid, sizeof(shmid), 0) != sizeof(shmid)) {
-		DBG("%s: send shmid failed on socket %s: %s", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno));
-		return -1;
-	}
-	if (send(recvsock, &action, sizeof(action), 0) != sizeof(action)) {
-		DBG("%s: send action failed on socket %s: %s", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno));
-		return -1;
-	}
-	return 0;
-}
-
-#define FUNC_ASHV_READ(type, var) \
-	type var; \
-	if (read(recvsock, &var, sizeof(type)) != sizeof(type)) { \
-		DBG("%s: ERROR: read %s failed", __PRETTY_FUNCTION__, #var); \
-		close(recvsock); \
-		return -1; \
+		DBG ("%s: send() failed on socket %s: %s", __PRETTY_FUNCTION__, addr.sun_path + 1, strerror(errno));
+		goto error_close;
 	}
 
-static int ashv_delete_remote_segment(int shmid)
-{
-	struct sockaddr_un addr;
-	int recvsock = ashv_connect_socket(&addr, shmid);
-	if (recvsock == -1) {
-		return -1;
-	}
-
-	int res = ashv_send_shmid_action(recvsock, &addr, shmid, ASHV_RM);
-
-	close(recvsock);
-	return res;
-}
-
-static int ashv_send_pid_remote_segment(int shmid, int action)
-{
-	struct sockaddr_un addr;
-	int recvsock = ashv_connect_socket(&addr, shmid);
-	if (recvsock == -1) {
-		return -1;
-	}
-
-	if (ashv_send_shmid_action(recvsock, &addr, shmid, action) == -1) {
-		close(recvsock);
-		return -1;
-	}
-
-	if (write(recvsock, &ashv_pid_setup, sizeof(pid_t)) != sizeof(pid_t)) {
-		DBG("%s: ERROR: write pid failed", __PRETTY_FUNCTION__);
-		close(recvsock);
-		return -1;
-        }
-
-	close(recvsock);
-	return 0;
-}
-
-static int ashv_attach_remote_segment(int shmid)
-{
-	return ashv_send_pid_remote_segment(shmid, ASHV_AT);
-}
-
-static int ashv_detach_remote_segment(int shmid)
-{
-	return ashv_send_pid_remote_segment(shmid, ASHV_DT);
-}
-
-static int ashv_read_remote_segment(int shmid)
-{
-	struct sockaddr_un addr;
-	int recvsock = ashv_connect_socket(&addr, shmid);
-	if (recvsock == -1) {
-		return -1;
-	}
-
-	if (ashv_send_shmid_action(recvsock, &addr, shmid, ASHV_GET) == -1) {
-		close(recvsock);
-		return -1;
-	}
-
-	FUNC_ASHV_READ(key_t, key)
-	FUNC_ASHV_READ(bool, markedForDeletion)
-	FUNC_ASHV_READ(int, countAttach)
-
-	if (markedForDeletion && countAttach == 0) {
-		DBG("%s: shmid %d is marked for deletion so it is not passed", __PRETTY_FUNCTION__, shmid);
-		close(recvsock);
-		return -1;
+	key_t key;
+	if (read(recvsock, &key, sizeof(key_t)) != sizeof(key_t)) {
+		DBG("%s: ERROR: failed read", __PRETTY_FUNCTION__);
+		goto error_close;
 	}
 
 	int descriptor = ancil_recv_fd(recvsock);
 	if (descriptor < 0) {
 		DBG("%s: ERROR: ancil_recv_fd() failed on socket %s: %s", __PRETTY_FUNCTION__, addr.sun_path + 1, strerror(errno));
-		close(recvsock);
-		return -1;
+		goto error_close;
 	}
 	close(recvsock);
+
+	int size = ashmem_get_size_region(descriptor);
+	if (size == 0 || size == -1) {
+		DBG ("%s: ERROR: ashmem_get_size_region() returned %d on socket %s: %s", __PRETTY_FUNCTION__, size, addr.sun_path + 1, strerror(errno));
+		return -1;
+	}
+
+	int idx = shmem_amount;
+	shmem_amount ++;
+	shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
+	shmem[idx].id = shmid;
+	shmem[idx].descriptor = descriptor;
+	shmem[idx].size = size;
+	shmem[idx].addr = NULL;
+	shmem[idx].markedForDeletion = false;
+	shmem[idx].key = key;
+	shmem[idx].countAttach = 0;
+        shmem[idx].global = false;
+	return idx;
+error_close:
+	close(recvsock);
+	return -1;
+}
+
+static void* ashv_thread_check_pids(void* arg) {
+	(void) arg;
+	while (true) {
+		pthread_mutex_lock(&mutex);
+		for (size_t i=0; i<shmem_amount; i++) {
+			android_shmem_check_pids(i);
+			if (shmem[i].markedForDeletion && shmem[i].countAttach == 0) {
+				android_shmem_delete(i);
+			}
+		}
+		if (shmem_amount == 0) {
+			close(global_sendsock);
+			exit(0);
+		}
+		pthread_mutex_unlock(&mutex);
+	}
+}
+
+#define GSOCKET_ASHV_WRITE(type, var) \
+	if (write(global_sendsock, &shmem[idx].var, sizeof(type)) != sizeof(type)) { \
+		DBG("%s: ERROR: write %s failed: %s", __PRETTY_FUNCTION__, #var, strerror(errno)); \
+		break; \
+	}
+
+#define GSOCKET_ASHV_READ(type, var) \
+	if (read(global_sendsock, &var, sizeof(type)) != sizeof(type)) { \
+		DBG("%s: ERROR: read %s failed: %s", __PRETTY_FUNCTION__, #var, strerror(errno)); \
+		break; \
+	}
+
+static int ashv_fork_function()
+{
+	pid_t p = fork();
+	if (p < 0) {
+		DBG("%s: ERROR: fork() failed", __PRETTY_FUNCTION__);
+		return -1;
+	}
+
+	if (p == 0) {
+		signal(SIGINT, SIG_IGN);
+		signal(SIGPIPE, SIG_IGN);
+	} else {
+		int ret = -1;
+		int size = strlen(ANDROID_SHMEM_GLOBAL_PROCNAME);
+		char path_comm[32];
+		sprintf(path_comm, "/proc/%d/comm", p);
+		while (kill(p, 0) == 0) {
+			int cf = open(path_comm, O_RDONLY);
+			if (cf == -1) {
+				break;
+			}
+			char* comm = malloc(size*sizeof(char));
+			if (read(cf, comm, size) != -1 && strcmp(comm, ANDROID_SHMEM_GLOBAL_PROCNAME) == 0) {
+				ret = 0;
+				break;
+			}
+			free(comm);
+			close(cf);
+		}
+		if (ret == 0) {
+			DBG("%s: fork() successfully started", __PRETTY_FUNCTION__);
+		} else {
+			DBG("%s: fork() failed to start global socket", __PRETTY_FUNCTION__);
+		}
+		return ret;
+	}
+
+	int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (!sock) {
+		DBG("%s: cannot create UNIX socket: %s", __PRETTY_FUNCTION__, strerror(errno));
+		exit(1);
+	}
+
+	struct sockaddr_un addr;
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	sprintf(&addr.sun_path[1], ANDROID_SHMEM_GLOBAL_SOCKNAME);
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr.sun_family)+strlen(&addr.sun_path[1])+1) != 0) {
+		DBG("%s: cannot bind UNIX socket", __PRETTY_FUNCTION__);
+		exit(1);
+	}
+
+	if (listen(sock, 4) != 0) {
+		DBG("%s: listen failed", __PRETTY_FUNCTION__);
+		exit(1);
+	}
+
+	pthread_mutex_unlock(&mutex);
+	pthread_t ptid;
+	pthread_create(&ptid, NULL, &ashv_thread_check_pids, NULL);
+	pthread_setname_np(pthread_self(), ANDROID_SHMEM_GLOBAL_PROCNAME);
+
+	struct sockaddr_un accept_addr;
+	socklen_t len = sizeof(accept_addr);
+	while ((global_sendsock=accept(sock, (struct sockaddr *)&accept_addr, &len)) != -1) {
+		int action;
+		if (recv(global_sendsock, &action, sizeof(action), 0) != sizeof(action)) {
+			DBG("%s: ERROR: recv() returned not %zu action bytes", __PRETTY_FUNCTION__, sizeof(action));
+			close(global_sendsock);
+			continue;
+		}
+		int shmid;
+		if (recv(global_sendsock, &shmid, sizeof(shmid), 0) != sizeof(shmid)) {
+			DBG("%s: ERROR: recv() returned not %zu shmid bytes", __PRETTY_FUNCTION__, sizeof(shmid));
+			close(global_sendsock);
+			continue;
+		}
+
+		pthread_mutex_lock(&mutex);
+		int status = -1;
+		int idx = ashv_find_local_index(shmid);
+		if (idx != -1 || action == ASHV_PUT) {
+			pid_t pid;
+			switch (action) {
+			case ASHV_PUT:
+				DBG("%s: action ASHV_PUT(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				if (idx == -1 && ashv_put_remote_segment(shmid) == -1) {
+					DBG("%s: ERROR: failed to get remote shm %d", __PRETTY_FUNCTION__, shmid);
+					break;
+				}
+				status = 0;
+				break;
+			case ASHV_GET:
+				DBG("%s: action ASHV_GET(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				GSOCKET_ASHV_WRITE(key_t, key)
+				GSOCKET_ASHV_WRITE(bool, markedForDeletion)
+				GSOCKET_ASHV_WRITE(int, countAttach)
+				if (ancil_send_fd(global_sendsock, shmem[idx].descriptor) != 0) {
+					DBG("%s: ERROR: ancil_send_fd() failed: %s", __PRETTY_FUNCTION__, strerror(errno));
+					break;
+				}
+				status = 0;
+				break;
+			case ASHV_UPD:
+				DBG("%s: action ASHV_UPD(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				GSOCKET_ASHV_WRITE(bool, markedForDeletion)
+				android_shmem_check_pids(idx);
+				GSOCKET_ASHV_WRITE(int, countAttach)
+				status = ashv_write_pids(global_sendsock, idx);
+				break;
+			case ASHV_RM:
+				DBG("%s: action ASHV_RM(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				ashv_delete_segment(idx);
+				status = 0;
+				break;
+			case ASHV_AT:
+				DBG("%s: action ASHV_AT(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				GSOCKET_ASHV_READ(pid_t, pid)
+				android_shmem_attach_pid(idx, pid);
+				status = 0;
+				break;
+			case ASHV_DT:
+				DBG("%s: action ASHV_DT(%d) for %d", __PRETTY_FUNCTION__, action, shmid);
+				GSOCKET_ASHV_READ(pid_t, pid)
+				android_shmem_detach_pid(idx, pid);
+				status = 0;
+				break;
+			default:
+				DBG("%s: ERROR: unknown action %d", __PRETTY_FUNCTION__, action);
+				break;
+			}
+		} else {
+			DBG("%s: ERROR: cannot find shmid 0x%x", __PRETTY_FUNCTION__, shmid);
+		}
+		if (write(global_sendsock, &status, sizeof(int)) != sizeof(int)) {
+			DBG("%s: ERROR: write status failed: %s", __PRETTY_FUNCTION__, strerror(errno));
+		}
+		pthread_mutex_unlock(&mutex);
+
+		close(global_sendsock);
+		len = sizeof(accept_addr);
+	}
+
+	DBG ("%s: ERROR: listen() failed, fork stopped", __PRETTY_FUNCTION__);
+	exit(1);
+}
+
+static int ashv_connect_gsocket(struct sockaddr_un *addr, int action, int shmid)
+{
+	memset(addr, 0, sizeof(*addr));
+	addr->sun_family = AF_UNIX;
+	sprintf(&addr->sun_path[1], ANDROID_SHMEM_GLOBAL_SOCKNAME);
+	int addrlen = sizeof(addr->sun_family) + strlen(&addr->sun_path[1]) + 1;
+
+	int gsock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (gsock == -1) {
+		DBG ("%s: cannot create UNIX socket: %s", __PRETTY_FUNCTION__, strerror(errno));
+		return -1;
+	}
+	if (connect(gsock, (struct sockaddr*)addr, addrlen) != 0) {
+		DBG("%s: Cannot connect to UNIX socket %s: %s, len %d", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno), addrlen);
+		goto close;
+	}
+
+	if (send(gsock, &action, sizeof(action), 0) != sizeof(action)) {
+		DBG("%s: send acction failed on socket %s: %s", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno));
+		goto close;
+	}
+	if (send(gsock, &shmid, sizeof(shmid), 0) != sizeof(shmid)) {
+		DBG("%s: send shmid failed on socket %s: %s", __PRETTY_FUNCTION__, addr->sun_path + 1, strerror(errno));
+		goto close;
+	}
+
+	global_conf = true;
+	return gsock;
+close:
+	close(gsock);
+	return -1;
+}
+
+static int ashv_status_gsocket(int gsock) {
+	int status;
+	if (read(gsock, &status, sizeof(int)) != sizeof(int)) {
+		DBG("%s: ERROR: read status failed", __PRETTY_FUNCTION__);
+		status = -1;
+	}
+	close(gsock);
+	global_conf = false;
+	return status;
+}
+
+static int ashv_one_action_gsocket(int action, int shmid)
+{
+	struct sockaddr_un addr;
+	int gsock = ashv_connect_gsocket(&addr, action, shmid);
+	if (gsock == -1) {
+		return -1;
+	}
+
+	return ashv_status_gsocket(gsock);
+}
+
+static int ashv_send_pid_gsocket(int action, int shmid)
+{
+	struct sockaddr_un addr;
+	int gsock = ashv_connect_gsocket(&addr, action, shmid);
+	if (gsock == -1) {
+		return -1;
+	}
+
+	if (write(gsock, &ashv_pid_setup, sizeof(pid_t)) != sizeof(pid_t)) {
+		DBG("%s: ERROR: write pid failed", __PRETTY_FUNCTION__);
+		close(gsock);
+		return -1;
+        }
+
+	return ashv_status_gsocket(gsock);
+}
+
+#define ASHV_READ_GSOCK(type, var) \
+	type var; \
+	if (read(gsock, &var, sizeof(type)) != sizeof(type)) { \
+		DBG("%s: ERROR: read %s failed", __PRETTY_FUNCTION__, #var); \
+		goto error_close; \
+	}
+
+static int ashv_get_shm_gsocket(int shmid)
+{
+	struct sockaddr_un addr;
+	int gsock = ashv_connect_gsocket(&addr, ASHV_GET, shmid);
+	if (gsock == -1) {
+		return -1;
+	}
+
+	ASHV_READ_GSOCK(key_t, key)
+	ASHV_READ_GSOCK(bool, markedForDeletion)
+	ASHV_READ_GSOCK(int, countAttach)
+
+	if (markedForDeletion && countAttach == 0) {
+		DBG("%s: shmid %d is marked for deletion so it is not passed", __PRETTY_FUNCTION__, shmid);
+		goto error_close;
+	}
+
+	int descriptor = ancil_recv_fd(gsock);
+	if (descriptor < 0) {
+		DBG("%s: ERROR: ancil_recv_fd() failed on socket %s: %s", __PRETTY_FUNCTION__, addr.sun_path + 1, strerror(errno));
+		goto error_close;
+	}
+	global_conf = false;
+	close(gsock);
 
 	int size = ashmem_get_size_region(descriptor);
 	if (size == 0 || size == -1) {
@@ -488,44 +676,44 @@ static int ashv_read_remote_segment(int shmid)
 	shmem[idx].markedForDeletion = markedForDeletion;
 	shmem[idx].key = key;
 	shmem[idx].countAttach = countAttach;
+	shmem[idx].global = true;
 	return idx;
+error_close:
+	global_conf = false;
+	close(gsock);
+	return -1;
 }
 
-static int ashv_get_update_remote_segment(int idx)
+static int ashv_update_shm_gsocket(int idx)
 {
 	int shmid = shmem[idx].id;
 	struct sockaddr_un addr;
-	int recvsock = ashv_connect_socket(&addr, shmid);
-	if (recvsock == -1) {
+	int gsock = ashv_connect_gsocket(&addr, ASHV_UPD, shmid);
+	if (gsock == -1) {
 		goto removal;
 	}
 
-	if (ashv_send_shmid_action(recvsock, &addr, shmid, ASHV_UPD) == -1) {
-		close(recvsock);
+	if (read(gsock, &shmem[idx].markedForDeletion, sizeof(bool)) != sizeof(bool)) {
+		close(gsock);
 		goto removal;
 	}
 
-	if (read(recvsock, &shmem[idx].markedForDeletion, sizeof(bool)) != sizeof(bool)) {
-		close(recvsock);
+	if (read(gsock, &shmem[idx].countAttach, sizeof(int)) != sizeof(int)) {
+		close(gsock);
 		goto removal;
 	}
 
-	if (read(recvsock, &shmem[idx].countAttach, sizeof(int)) != sizeof(int)) {
-		close(recvsock);
+	if (ashv_read_pids(gsock, idx) != 0) {
+		close(gsock);
 		goto removal;
 	}
 
-	if (ashv_read_pids(recvsock, idx) != 0) {
-		close(recvsock);
-		goto removal;
-	}
-
-	close(recvsock);
-	return 0;
+	return ashv_status_gsocket(gsock);
 removal:
-	DBG("%s: socket returned an error, shm %d will have a delete mark", __PRETTY_FUNCTION__, shmid);
+	DBG("%s: gsocket returned an error, shm %d will have a delete mark", __PRETTY_FUNCTION__, shmid);
 	shmem[idx].countAttach = 0;
 	shmem[idx].markedForDeletion = true;
+	shmem[idx].global = false;
 	shmem[idx].attachedPids = NULL;
 	if (shmem[idx].addr != NULL) {
 		android_shmem_attach_pid(idx, ashv_pid_setup);
@@ -533,11 +721,15 @@ removal:
 	return -1;
 }
 
+#define FIND_SHMEM \
+	int idx = ashv_find_local_index(shmid); \
+	if (idx == -1 && (idx = ashv_get_shm_gsocket(shmid)) == -1 && ashv_socket_id_from_shmid(shmid) != ashv_local_socket_id) { \
+		idx = ashv_put_remote_segment(shmid); \
+	}
+
 /* Get shared memory area identifier. */
 int shmget(key_t key, size_t size, int flags)
 {
-	(void) flags;
-
 	ashv_check_pid();
 
 	// Counter wrapping around at 15 bits.
@@ -598,18 +790,9 @@ int shmget(key_t key, size_t size, int flags)
 				path_buffer[path_length] = '\0';
 				int shmid = atoi(path_buffer);
 				if (shmid != 0) {
-					int socket_id = ashv_socket_id_from_shmid(shmid);
-					int idx = ashv_find_local_index(shmid);
-					if (idx == -1 && socket_id != ashv_local_socket_id) {
-						idx = ashv_read_remote_segment(shmid);
-					}
-
-					if (idx != -1) {
-						if (socket_id != ashv_local_socket_id) {
-							ashv_get_update_remote_segment(idx);
-						} else {
-							android_shmem_check_pids(idx);
-						}
+					FIND_SHMEM
+					if (idx != -1 && shmem[idx].global) {
+						ashv_update_shm_gsocket(idx);
 						if (shmem[idx].markedForDeletion && shmem[idx].countAttach == 0) {
 							android_shmem_delete(idx);
 							idx = -1;
@@ -654,6 +837,13 @@ int shmget(key_t key, size_t size, int flags)
 	int idx = shmem_amount;
 	char buf[256];
 	sprintf(buf, ANDROID_SHMEM_SOCKNAME "-%d", ashv_local_socket_id, idx);
+	size = ROUND_UP(size, getpagesize());
+	int descriptor = ashmem_create_region(buf, size);
+	if (descriptor < 0) {
+		DBG("%s: ashmem_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
+		pthread_mutex_unlock(&mutex);
+		return -1;
+	}
 
 	shmem_amount++;
 	if (shmid == -1) {
@@ -662,23 +852,19 @@ int shmget(key_t key, size_t size, int flags)
 	}
 
 	shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
-	size = ROUND_UP(size, getpagesize());
 	shmem[idx].size = size;
-	shmem[idx].descriptor = ashmem_create_region(buf, size);
+	shmem[idx].descriptor = descriptor;
 	shmem[idx].addr = NULL;
 	shmem[idx].id = shmid;
 	shmem[idx].markedForDeletion = false;
 	shmem[idx].key = key;
 	shmem[idx].countAttach = 0;
 	shmem[idx].attachedPids = NULL;
-
-	if (shmem[idx].descriptor < 0) {
-		DBG("%s: ashmem_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
-		shmem_amount --;
-		shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
-		pthread_mutex_unlock (&mutex);
-		return -1;
+	shmem[idx].global = false;
+	if (ashv_one_action_gsocket(ASHV_PUT, shmid) == 0 || ashv_fork_function() == 0) {
+		shmem[idx].global = true;
 	}
+
 	//DBG("%s: ID %d shmid %x FD %d size %zu", __PRETTY_FUNCTION__, idx, shmid, shmem[idx].descriptor, shmem[idx].size);
 	/*
 	status = ashmem_set_prot_region (shmem[idx].descriptor, 0666);
@@ -706,21 +892,15 @@ int shmget(key_t key, size_t size, int flags)
 }
 
 #define INIT_SHMEM(ret_err) \
-	int socket_id = ashv_socket_id_from_shmid(shmid); \
-	int idx = ashv_find_local_index(shmid); \
-	if (idx == -1 && socket_id != ashv_local_socket_id) { \
-		idx = ashv_read_remote_segment(shmid); \
-	} \
+	FIND_SHMEM \
 	if (idx == -1) { \
 		DBG ("%s: ERROR: shmid %x does not exist\n", __PRETTY_FUNCTION__, shmid); \
 		pthread_mutex_unlock(&mutex); \
 		errno = EINVAL; \
 		return ret_err; \
 	} \
-	if (socket_id != ashv_local_socket_id) { \
-		ashv_get_update_remote_segment(idx); \
-	} else { \
-		android_shmem_check_pids(idx); \
+	if (shmem[idx].global) { \
+		ashv_update_shm_gsocket(idx); \
 	} \
 	if (shmem[idx].markedForDeletion && shmem[idx].countAttach == 0) { \
 		DBG ("%s: shmid %d marked for deletion, it will be deleted\n", __PRETTY_FUNCTION__, shmid); \
@@ -742,18 +922,18 @@ void* shmat(int shmid, void const* shmaddr, int shmflg)
 	INIT_SHMEM((void*)-1)
 
 	if (shmem[idx].addr == NULL) {
-		if (socket_id != ashv_local_socket_id) {
-			ashv_attach_remote_segment(shmid);
+		if (shmem[idx].global) {
+			ashv_send_pid_gsocket(ASHV_AT, shmid);
 		}
 		android_shmem_attach_pid(idx, ashv_pid_setup);
 		shmem[idx].addr = mmap((void*) shmaddr, shmem[idx].size, PROT_READ | (shmflg == 0 ? PROT_WRITE : 0), MAP_SHARED, shmem[idx].descriptor, 0);
 		if (shmem[idx].addr == MAP_FAILED) {
-			DBG ("%s: mmap() failed for ID %x FD %d: %s\n", __PRETTY_FUNCTION__, idx, shmem[idx].descriptor, strerror(errno));
+			DBG ("%s: mmap() failed for ID %x FD %d: %s", __PRETTY_FUNCTION__, idx, shmem[idx].descriptor, strerror(errno));
 			shmem[idx].addr = NULL;
 		}
 	}
 	addr = shmem[idx].addr;
-	DBG ("%s: mapped addr %p for FD %d ID %d\n", __PRETTY_FUNCTION__, addr, shmem[idx].descriptor, idx);
+	DBG ("%s: mapped addr %p for FD %d ID %d", __PRETTY_FUNCTION__, addr, shmem[idx].descriptor, idx);
 	pthread_mutex_unlock (&mutex);
 
 	return addr ? addr : (void *)-1;
@@ -768,33 +948,86 @@ int shmdt(void const* shmaddr)
 	for (size_t i = 0; i < shmem_amount; i++)
 		if (shmem[i].addr == shmaddr) {
 			if (munmap(shmem[i].addr, shmem[i].size) != 0) {
-				DBG("%s: munmap %p failed\n", __PRETTY_FUNCTION__, shmaddr);
+				DBG("%s: munmap %p failed", __PRETTY_FUNCTION__, shmaddr);
 			}
 			shmem[i].addr = NULL;
-			DBG("%s: unmapped addr %p for FD %d ID %zu shmid %x\n", __PRETTY_FUNCTION__, shmaddr, shmem[i].descriptor, i, shmem[i].id);
+			DBG("%s: unmapped addr %p for FD %d ID %zu shmid %x", __PRETTY_FUNCTION__, shmaddr, shmem[i].descriptor, i, shmem[i].id);
 
-			int socket_id = ashv_socket_id_from_shmid(shmem[i].id);
-			if (socket_id != ashv_local_socket_id) {
-				ashv_get_update_remote_segment(i);
-				ashv_detach_remote_segment(shmem[i].id);
-			} else {
-				android_shmem_check_pids(i);
+			if (shmem[i].global) {
+				ashv_update_shm_gsocket(i);
+				ashv_send_pid_gsocket(ASHV_DT, shmem[i].id);
 			}
 			android_shmem_detach_pid(i, ashv_pid_setup);
 
 			if (shmem[i].markedForDeletion && shmem[i].countAttach == 0) {
-				DBG ("%s: deleting shmid %x\n", __PRETTY_FUNCTION__, shmem[i].id);
-				android_shmem_delete(i);
-				if (socket_id != ashv_local_socket_id) {
-					ashv_delete_remote_segment(shmem[i].id);
+				DBG ("%s: deleting shmid %x", __PRETTY_FUNCTION__, shmem[i].id);
+				if (shmem[i].global) {
+					ashv_one_action_gsocket(ASHV_RM, shmem[i].id);
 				}
+				android_shmem_delete(i);
 			}
 			pthread_mutex_unlock(&mutex);
 			return 0;
 	}
 	pthread_mutex_unlock(&mutex);
 
-	DBG("%s: invalid address %p\n", __PRETTY_FUNCTION__, shmaddr);
+	DBG("%s: invalid address %p", __PRETTY_FUNCTION__, shmaddr);
+	/* Could be a remove segment, do not report an error for that. */
+	return 0;
+}
+
+/* Let PRoot attach shared memory segment to another process. */
+int libandroid_shmat_fd(int shmid, size_t* out_size)
+{
+	ashv_check_pid();
+
+	int fd;
+
+	pthread_mutex_lock(&mutex);
+
+	INIT_SHMEM(-1)
+
+	if (shmem[idx].global) {
+		ashv_send_pid_gsocket(ASHV_AT, shmid);
+	}
+
+	fd = shmem[idx].descriptor;
+	*out_size = shmem[idx].size;
+	DBG ("%s: mapped for FD %d ID %d", __PRETTY_FUNCTION__, shmem[idx].descriptor, idx);
+	pthread_mutex_unlock (&mutex);
+
+	return fd;
+}
+
+/* Let PRoot detach shared memory segment after last process detached. */
+int libandroid_shmdt_fd(int fd)
+{
+	ashv_check_pid();
+
+	pthread_mutex_lock(&mutex);
+	for (size_t i = 0; i < shmem_amount; i++) {
+		if (shmem[i].descriptor == fd) {
+			DBG("%s: unmapped for FD %d ID %zu shmid %x", __PRETTY_FUNCTION__, shmem[i].descriptor, i, shmem[i].id);
+			if (shmem[i].global) {
+				ashv_update_shm_gsocket(i);
+				ashv_send_pid_gsocket(ASHV_DT, shmem[i].id);
+			}
+			android_shmem_detach_pid(i, ashv_pid_setup);
+
+			if (shmem[i].markedForDeletion && shmem[i].countAttach == 0) {
+				DBG ("%s: deleting shmid %x", __PRETTY_FUNCTION__, shmem[i].id);
+				if (shmem[i].global) {
+					ashv_one_action_gsocket(ASHV_RM, shmem[i].id);
+				}
+				android_shmem_delete(i);
+			}
+			pthread_mutex_unlock(&mutex);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&mutex);
+
+	DBG("%s: invalid fd %d", __PRETTY_FUNCTION__, fd);
 	/* Could be a remove segment, do not report an error for that. */
 	return 0;
 }
@@ -810,19 +1043,19 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 
 	switch (cmd) {
 	case IPC_RMID:
-		DBG("%s: IPC_RMID for shmid=%x\n", __PRETTY_FUNCTION__, shmid);
+		DBG("%s: IPC_RMID for shmid=%x", __PRETTY_FUNCTION__, shmid);
 
-		ashv_delete_segment(idx);
-		if (socket_id != ashv_local_socket_id) {
-			ashv_delete_remote_segment(shmid);
+		if (shmem[idx].global) {
+			ashv_one_action_gsocket(ASHV_RM, shmid);
 		}
+		ashv_delete_segment(idx);
 
 		goto ok;
 	case SHM_STAT:
 	case SHM_STAT_ANY:
 	case IPC_STAT:
 		if (!buf) {
-			DBG ("%s: ERROR: buf == NULL for shmid %x\n", __PRETTY_FUNCTION__, shmid);
+			DBG ("%s: ERROR: buf == NULL for shmid %x", __PRETTY_FUNCTION__, shmid);
 			goto error;
 		}
 
@@ -840,7 +1073,7 @@ int shmctl(int shmid, int cmd, struct shmid_ds *buf)
 
 		goto ok;
 	default:
-		DBG("%s: cmd %d not implemented yet!\n", __PRETTY_FUNCTION__, cmd);
+		DBG("%s: cmd %d not implemented yet!", __PRETTY_FUNCTION__, cmd);
 		goto error;
 	}
 ok:

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ cleanup-memory: test
 	./cleanup-shared-memory.sh
 endif
 
-test: $(addprefix testcase-,$(patsubst %.c,%,$(wildcard *.c))) ;
+test: $(addprefix testcase-,$(patsubst %.c,%,$(wildcard *.c))) test-interactions-shm ;
 
 testcase-% : test-%
 	./$^
@@ -21,8 +21,12 @@ testcase-% : test-%
 test-%: %.c $(EXTRA_CFILE)
 	$(CC) $(CFLAGS) $+ -o $@
 
+test-interactions-shm: ./interactions-shm/
+	$(MAKE) -C ./interactions-shm/
+
 clean:
 	rm -f test-*
+	$(MAKE) clean -C ./interactions-shm/
 
 .PHONY: clean \
 	test \

--- a/test/after-fork.c
+++ b/test/after-fork.c
@@ -18,6 +18,7 @@ int main() {
 		if ((shm_child = shmat(shmid, NULL, 0)) == (char*) -1) error_exit("shmat-child-2");
 		shm_child[1] = '#';
 		if (shmdt(shm_child) != 0) error_exit("shmdt-child-2");
+		if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl-child");
 		return 0;
 	} else {
 		int shmid;

--- a/test/at-memory.c
+++ b/test/at-memory.c
@@ -20,6 +20,7 @@ int main() {
 		if (shm_child_copy != shm_child) failure_exit("not-at-requested-memory");
 		shm_child[1] = '#';
 		if (shmdt(shm_child) != 0) error_exit("shmdt-child-2");
+		if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl-child");
 		return 0;
 	} else {
 		int shmid;

--- a/test/deadlock.c
+++ b/test/deadlock.c
@@ -6,6 +6,7 @@ int main() {
     int shmid_from_shmget;
     if ((shmid_from_shmget = shmget(SHMEM_KEY, 30, IPC_CREAT | 0666)) < 0) error_exit("shmget");
     if ((shmid_from_shmget = shmget(SHMEM_KEY, 30, IPC_CREAT | 0666)) < 0) error_exit("shmget");
+    if (shmctl(shmid_from_shmget, IPC_RMID, 0) == -1) error_exit("shmctl");
 
     return 0;
 }

--- a/test/error-codes.c
+++ b/test/error-codes.c
@@ -8,4 +8,5 @@ int main() {
 	if (errno != EINVAL) error_exit("shmat-wrong-errno");
 	int shmid;
 	if ((shmid = shmget(IPC_PRIVATE, 30, IPC_CREAT | 0666)) < 0) error_exit("shmget");
+	if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl");
 }

--- a/test/interactions-shm/Makefile
+++ b/test/interactions-shm/Makefile
@@ -13,54 +13,19 @@ cleanup-memory: test
 	../cleanup-shared-memory.sh
 endif
 
-test: testcase-1 testcase-2 testcase-3
+test: testcase-1 testcase-2 testcase-3 testcase-4
 
-testcase-1: test-host test-remove host-available.sh
-	./test-host &
-	sleep 0.1
+testcase-1: test-create-shm test-remove shm-available.sh testcase-1.sh
+	bash ./testcase-1.sh
 
-	./test-remove
-	./host-available.sh no
+testcase-2: test-create-shm test-write test-read test-remove shm-available.sh testcase-2.sh
+	bash ./testcase-2.sh
 
-testcase-2: test-host test-write test-read test-remove host-available.sh
-	./test-host &
-	sleep 0.1
+testcase-3: test-create-shm test-create-ipc test-remove shm-available.sh testcase-3.sh
+	bash ./testcase-3.sh
 
-	./test-host && exit 1 || true
-	./host-available.sh yes
-
-	./test-write
-	./test-read
-
-	./test-remove
-
-testcase-3: test-host test-write test-read test-endless-attachment test-status test-remove host-available.sh check-attachments.sh
-	./test-host &
-	sleep 0.1
-
-	./check-attachments.sh
-
-	./test-endless-attachment &
-	sleep 0.1
-
-	./check-attachments.sh
-
-	./test-endless-attachment &
-	sleep 0.1
-
-	./check-attachments.sh
-
-	./test-remove
-	./host-available.sh yes
-
-	kill $$(pidof -s test-endless-attachment)
-	./host-available.sh yes
-
-	./test-write
-	./test-read
-
-	kill $$(pidof -s test-endless-attachment)
-	./host-available.sh no
+testcase-4: test-create-shm test-write test-read test-endless-attachment test-status test-remove shm-available.sh check-attachments.sh
+	bash ./testcase-4.sh
 
 test-%: %.c $(EXTRA_CFILE)
 	$(CC) $(CFLAGS) $+ -o $@

--- a/test/interactions-shm/Makefile
+++ b/test/interactions-shm/Makefile
@@ -1,0 +1,74 @@
+CFLAGS += -Wall -Wextra -Werror -std=c99 -I..
+
+OS := $(shell uname -o 2> /dev/null)
+
+ifeq ($(OS), Android)
+CFLAGS += -I../.. -llog
+EXTRA_CFILE = ../../shmem.c
+cleanup-memory: test ;
+else
+CFLAGS += -DSYSV_ASHMEM_TEST_SYSTEM
+EXTRA_CFILE =
+cleanup-memory: test
+	../cleanup-shared-memory.sh
+endif
+
+test: testcase-1 testcase-2 testcase-3
+
+testcase-1: test-host test-remove host-available.sh
+	./test-host &
+	sleep 0.1
+
+	./test-remove
+	./host-available.sh no
+
+testcase-2: test-host test-write test-read test-remove host-available.sh
+	./test-host &
+	sleep 0.1
+
+	./test-host && exit 1 || true
+	./host-available.sh yes
+
+	./test-write
+	./test-read
+
+	./test-remove
+
+testcase-3: test-host test-write test-read test-endless-attachment test-status test-remove host-available.sh check-attachments.sh
+	./test-host &
+	sleep 0.1
+
+	./check-attachments.sh
+
+	./test-endless-attachment &
+	sleep 0.1
+
+	./check-attachments.sh
+
+	./test-endless-attachment &
+	sleep 0.1
+
+	./check-attachments.sh
+
+	./test-remove
+	./host-available.sh yes
+
+	kill $$(pidof -s test-endless-attachment)
+	./host-available.sh yes
+
+	./test-write
+	./test-read
+
+	kill $$(pidof -s test-endless-attachment)
+	./host-available.sh no
+
+test-%: %.c $(EXTRA_CFILE)
+	$(CC) $(CFLAGS) $+ -o $@
+
+clean:
+	rm -f test-*
+
+.PHONY: clean \
+	test
+
+.PRECIOUS: test-%

--- a/test/interactions-shm/check-attachments.sh
+++ b/test/interactions-shm/check-attachments.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+ca=$(./test-status)
+cr=$(pidof test-endless-attachment | tr ' ' '\n' | wc -l)
+
+if [ "${ca}" = "${cr}" ]; then
+	echo "check-attachments - ok"
+	exit 0
+fi
+
+echo "check-attachments - no matches (ca:${ca} vs cr:${cr})"
+for pid in $(pidof test-endless-attachment); do
+	kill $pid
+done
+./test-remove &> /dev/null || true
+exit 1

--- a/test/interactions-shm/create-ipc.c
+++ b/test/interactions-shm/create-ipc.c
@@ -1,0 +1,8 @@
+#include "utils.h"
+
+int main() {
+	int shmid;
+	if ((shmid = shmget(IPC_PRIVATE, 30, 0666)) < 0) error_exit("shmget");
+	printf("%d\n", shmid);
+	return 0;
+}

--- a/test/interactions-shm/create-shm.c
+++ b/test/interactions-shm/create-shm.c
@@ -4,8 +4,6 @@ int main() {
 	key_t key;
 	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
 	if (shmget(key, 30, IPC_CREAT | IPC_EXCL | 0666) < 0) error_exit("shmget");
-	while (shmget(key, 30, 0666) > 0)
-		continue;
-	printf("host - ok\n");
+	printf("create-shm - ok\n");
 	return 0;
 }

--- a/test/interactions-shm/endless-attachment.c
+++ b/test/interactions-shm/endless-attachment.c
@@ -1,0 +1,13 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	int shmid;
+	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	if (shmat(shmid, NULL, 0) == (void*) -1) error_exit("shmat");
+	printf("endless-attachment - ok\n");
+	while (1)
+		continue;
+	return 0;
+}

--- a/test/interactions-shm/host-available.sh
+++ b/test/interactions-shm/host-available.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+status=$(pidof -q test-host && echo yes || echo no)
+echo "host available: $status"
+[ "${status}" = "${1}" ]
+exit $?

--- a/test/interactions-shm/host.c
+++ b/test/interactions-shm/host.c
@@ -1,0 +1,11 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	if (shmget(key, 30, IPC_CREAT | IPC_EXCL | 0666) < 0) error_exit("shmget");
+	while (shmget(key, 30, 0666) > 0)
+		continue;
+	printf("host - ok\n");
+	return 0;
+}

--- a/test/interactions-shm/read.c
+++ b/test/interactions-shm/read.c
@@ -1,0 +1,15 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	int shmid;
+	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	char *shm;
+	if ((shm = shmat(shmid, NULL, 0)) == (char*) -1) error_exit("shmat");
+	printf("%s\n", shm);
+	if (strcmp(TEST_TEXT, shm) != 0) error_exit("strcmp");
+	if (shmdt(shm) != 0) error_exit("shmdt");
+	printf("read - ok\n");
+	return 0;
+}

--- a/test/interactions-shm/remove.c
+++ b/test/interactions-shm/remove.c
@@ -1,10 +1,14 @@
 #include "utils.h"
 
-int main() {
-	key_t key;
-	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+int main(int argc, char **argv) {
 	int shmid;
-	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	if (argc > 1) {
+		if ((shmid = atoi(argv[1])) == 0) error_exit("atoi");
+	} else {
+		key_t key;
+		if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+		if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	}
 	if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl");
 	printf("remove - ok\n");
 	return 0;

--- a/test/interactions-shm/remove.c
+++ b/test/interactions-shm/remove.c
@@ -1,0 +1,11 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	int shmid;
+	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl");
+	printf("remove - ok\n");
+	return 0;
+}

--- a/test/interactions-shm/shm-available.sh
+++ b/test/interactions-shm/shm-available.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-status=$(pidof -q test-host && echo yes || echo no)
+status=$(grep global-shmem /proc/*/comm | wc -l)
 echo "host available: $status"
 [ "${status}" = "${1}" ]
 exit $?

--- a/test/interactions-shm/status.c
+++ b/test/interactions-shm/status.c
@@ -1,0 +1,12 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	int shmid;
+	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	struct shmid_ds buf;
+	if (shmctl(shmid, IPC_STAT, &buf) == -1) error_exit("shmctl");
+	printf("%lu\n", buf.shm_nattch);
+	return 0;
+}

--- a/test/interactions-shm/testcase-1.sh
+++ b/test/interactions-shm/testcase-1.sh
@@ -1,0 +1,5 @@
+./test-create-shm
+./shm-available.sh 1
+
+./test-remove
+./shm-available.sh 0

--- a/test/interactions-shm/testcase-2.sh
+++ b/test/interactions-shm/testcase-2.sh
@@ -1,0 +1,10 @@
+./test-create-shm
+
+./test-create-shm && exit 1 || true
+./shm-available.sh 1
+
+./test-write
+./test-read
+
+./test-remove
+./shm-available.sh 0

--- a/test/interactions-shm/testcase-3.sh
+++ b/test/interactions-shm/testcase-3.sh
@@ -1,0 +1,20 @@
+./test-create-shm
+
+IPC1=$(./test-create-ipc)
+echo ${IPC1}
+./shm-available.sh 1
+IPC2=$(./test-create-ipc)
+echo ${IPC2}
+./shm-available.sh 1
+IPC3=$(./test-create-ipc)
+echo ${IPC3}
+./shm-available.sh 1
+
+./test-remove
+./shm-available.sh 1
+./test-remove ${IPC1}
+./shm-available.sh 1
+./test-remove ${IPC2}
+./shm-available.sh 1
+./test-remove ${IPC3}
+./shm-available.sh 0

--- a/test/interactions-shm/testcase-4.sh
+++ b/test/interactions-shm/testcase-4.sh
@@ -1,0 +1,21 @@
+./test-create-shm
+
+./check-attachments.sh
+
+./test-endless-attachment &
+./check-attachments.sh
+
+./test-endless-attachment &
+./check-attachments.sh
+
+./test-remove
+./shm-available.sh yes
+
+kill $(pidof -s test-endless-attachment)
+./shm-available.sh 1
+
+./test-write
+./test-read
+
+kill $(pidof -s test-endless-attachment)
+./shm-available.sh 0

--- a/test/interactions-shm/write.c
+++ b/test/interactions-shm/write.c
@@ -1,0 +1,14 @@
+#include "utils.h"
+
+int main() {
+	key_t key;
+	if ((key = ftok(".", 1)) == -1) error_exit("ftok");
+	int shmid;
+	if ((shmid = shmget(key, 30, 0666)) < 0) error_exit("shmget");
+	char *shm;
+	if ((shm = shmat(shmid, NULL, 0)) == (char*) -1) error_exit("shmat");
+	memcpy(shm, TEST_TEXT, sizeof(TEST_TEXT));
+	if (shmdt(shm) != 0) error_exit("shmdt");
+	printf("write - ok\n");
+	return 0;
+}

--- a/test/ipc-private.c
+++ b/test/ipc-private.c
@@ -25,6 +25,7 @@ int main() {
 		if ((shm_child = shmat(shmid, NULL, 0)) == (char*) -1) error_exit("shmat-child");
 		shm_child[1] = '#';
 		if (shmdt(shm_child) != 0) error_exit("shmdt-child-2");
+		if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl-child");
 
 		// Create a new shared memory segment in the child to check that the
 		// parent can access it.
@@ -40,6 +41,7 @@ int main() {
 		int dummy;
 		if (read(exit_pipes[0], &dummy, sizeof(int)) != sizeof(int)) error_exit("read-pipe");
 
+		if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl-child-2");
 		return 0;
 	} else {
 		int shmid_from_child;

--- a/test/utils.h
+++ b/test/utils.h
@@ -13,6 +13,8 @@
 # include "shm.h"
 #endif
 
+#define TEST_TEXT "Hello, Test!"
+
 void error_exit(char const* msg) {
 	perror(msg);
 	exit(1);

--- a/test/with-key.c
+++ b/test/with-key.c
@@ -36,6 +36,7 @@ int main() {
 		if ((shm_child = shmat(shmid, NULL, 0)) == (char*) -1) error_exit("shmat-child-2");
 		shm_child[1] = '#';
 		if (shmdt(shm_child) != 0) error_exit("shmdt-child-2");
+		if (shmctl(shmid, IPC_RMID, 0) == -1) error_exit("shmctl-child");
 		return 0;
 	} else {
 		int shmid;


### PR DESCRIPTION
The possibility of remote interaction with shmem is implemented, i.e. the shmem socket is multifunctional and can not only send data, but also start an action and update shmem data. This allows you to implement shmem actions close to the original system V shared memory from Linux. For example:
 - Delete shmem if the process is not native
 - Count the number of attached and process ids