### PR TITLE
Fixes for QEMU support

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -451,7 +451,9 @@ void* shmat(int shmid, void const* shmaddr, int shmflg)
 	}
 
 	if (shmem[idx].addr == NULL) {
-		shmem[idx].addr = mmap((void*) shmaddr, shmem[idx].size, PROT_READ | (shmflg == 0 ? PROT_WRITE : 0), MAP_SHARED, shmem[idx].descriptor, 0);
+		int mmap_prot = PROT_READ | ((shmflg & SHM_RDONLY) == 0 ? PROT_WRITE : 0);
+		int mmap_flags = MAP_SHARED | (shmaddr != 0 ? MAP_FIXED : 0);
+		shmem[idx].addr = mmap((void*) shmaddr, shmem[idx].size, mmap_prot, mmap_flags, shmem[idx].descriptor, 0);
 		if (shmem[idx].addr == MAP_FAILED) {
 			DBG ("%s: mmap() failed for ID %x FD %d: %s", __PRETTY_FUNCTION__, idx, shmem[idx].descriptor, strerror(errno));
 			shmem[idx].addr = NULL;


### PR DESCRIPTION
Set MAP_FIXED when addr isn't NULL and don't assume that shmflg != 0 means SHM_RDONLY

termux/proot-distro#495

QEMU implies use of `SHM_REMAP`: https://github.com/qemu/qemu/blob/495de0fd82d8bb2d7035f82d9869cfeb48de2f9e/linux-user/mmap.c#L1420-L1423

In Linux, `addr != 0` implies `MAP_FIXED`, while `SHM_REMAP` flag only requires use of `addr != 0`: https://github.com/torvalds/linux/blob/7ff71e6d923969d933e1ba7e0db857782d36cd19/ipc/shm.c#L1534-L1555