### PR TITLE
Use `ASharedMemory` if targeting API level 26 or later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ libandroid-shmem.a: shmem.o
 	$(AR) rcu $@ shmem.o
 
 libandroid-shmem.so: shmem.o
-	$(CC) $(LDFLAGS) -shared shmem.o -o $@ -llog
+	$(CC) $(LDFLAGS) -shared shmem.o -o $@ -llog -landroid
 
 shmem.o: shmem.c shm.h
 	$(CC) $(CFLAGS) -c shmem.c -o $@


### PR DESCRIPTION
Use the public [ASharedMemory API](https://developer.android.com/ndk/reference/group/memory) when available (when targeting API level 26+) as direct `/dev/ashmem` access [is not allowed from Android 10 or later](https://developer.android.com/about/versions/10/behavior-changes-10#shared-memory):

> Apps targeting Android 10 cannot directly use ashmem (/dev/ashmem) and must
> instead access shared memory via the NDK’s ASharedMemory class

Builds targeting API levels < 26 (where `ASharedMemory` is not available) are unaffected.