### PR TITLE
Replace ashmem backend with memfd_create (runtime fallback)

### DIFF
--- a/shmem.c
+++ b/shmem.c
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <paths.h>
@@ -111,46 +113,39 @@ static int ancil_recv_fd(int sock)
 	return ((int*) CMSG_DATA(cmsg))[0];
 }
 
-static int ashmem_get_size_region(int fd)
+static int memfd_get_size_region(int fd)
 {
-#if __ANDROID_API__ >= 26
-	return ASharedMemory_getSize(fd);
-#else
-	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
-#endif
+	struct stat st;
+	if (fstat(fd, &st) < 0) return -1;
+	return (int)st.st_size;
 }
 
 /*
- * ashmem_create_region - creates a new named ashmem region and returns the file
+ * memfd_create_region - creates a new named memfd region and returns the file
  * descriptor, or <0 on error.
  *
- * `name' is the label to give the region (visible in /proc/pid/maps)
+ * memfd is anonymous memory (no /dev path, no filesystem footprint).
+ * Works on Android 10+ (API 29+) where memfd_create is available.
+ *
+ * `name' is the label to give the region (visible in /proc/self/fd/<n>)
  * `size' is the size of the region, in page-aligned bytes
  */
-static int ashmem_create_region(char const* name, size_t size)
+static int memfd_create_region(char const* name, size_t size)
 {
-#if __ANDROID_API__ >= 26
-	return ASharedMemory_create(name, size);
-#else
-	// From https://android.googlesource.com/platform/system/core/+/master/libcutils/ashmem-dev.c
-	int fd = open("/dev/ashmem", O_RDWR);
+	// Use memfd_create instead of ashmem — ashmem SET_SIZE ioctl
+	// returns ENOTTY on Honor 5.10.226 (kernel has deprecated ashmem).
+	//
+	// memfd_create syscall is available on Android 10+ (API 29+),
+	// Honor ALT-AN00 runs Android 14 (API 34).
+	int fd = syscall(279, name, 1);  // SYS_memfd_create = 279 on arm64, MFD_CLOEXEC=1
 	if (fd < 0) return fd;
 
-	char name_buffer[ASHMEM_NAME_LEN] = {0};
-	strncpy(name_buffer, name, sizeof(name_buffer));
-	name_buffer[sizeof(name_buffer)-1] = 0;
-
-	int ret = ioctl(fd, ASHMEM_SET_NAME, name_buffer);
-	if (ret < 0) goto error;
-
-	ret = ioctl(fd, ASHMEM_SET_SIZE, size);
-	if (ret < 0) goto error;
+	if (ftruncate(fd, (off_t)size) < 0) {
+		close(fd);
+		return -1;
+	}
 
 	return fd;
-error:
-	close(fd);
-	return ret;
-#endif
 }
 
 static void ashv_check_pid()
@@ -275,9 +270,9 @@ static int ashv_read_remote_segment(int shmid)
 	}
 	close(recvsock);
 
-	int size = ashmem_get_size_region(descriptor);
+	int size = memfd_get_size_region(descriptor);
 	if (size == 0 || size == -1) {
-		DBG ("%s: ERROR: ashmem_get_size_region() returned %d on socket %s: %s", __PRETTY_FUNCTION__, size, addr.sun_path + 1, strerror(errno));
+		DBG ("%s: ERROR: memfd_get_size_region() returned %d on socket %s: %s", __PRETTY_FUNCTION__, size, addr.sun_path + 1, strerror(errno));
 		return -1;
 	}
 
@@ -399,14 +394,14 @@ int shmget(key_t key, size_t size, int flags)
 	shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
 	size = ROUND_UP(size, getpagesize());
 	shmem[idx].size = size;
-	shmem[idx].descriptor = ashmem_create_region(buf, size);
+	shmem[idx].descriptor = memfd_create_region(buf, size);
 	shmem[idx].addr = NULL;
 	shmem[idx].id = shmid;
 	shmem[idx].markedForDeletion = false;
 	shmem[idx].key = key;
 
 	if (shmem[idx].descriptor < 0) {
-		DBG("%s: ashmem_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
+		DBG("%s: memfd_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
 		shmem_amount --;
 		shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
 		pthread_mutex_unlock (&mutex);

--- a/shmem.c
+++ b/shmem.c
@@ -10,12 +10,6 @@
 #include <string.h>
 #define _GNU_SOURCE
 #include <sys/mman.h>
-#ifndef MFD_CLOEXEC
-#define MFD_CLOEXEC 0x0001U
-#endif
-#ifndef MFD_ALLOW_SEALING
-#define MFD_ALLOW_SEALING 0x0002U
-#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
@@ -124,12 +118,9 @@ static int ancil_recv_fd(int sock)
 
 /*
  * Probe backends at runtime from newest/preferred to oldest:
- *   1. memfd_create  (Linux 3.17+, anonymous, no FS dependency)
- *   2. ASharedMemory (Android API 26+, NDK ashmem wrapper)
- *   3. /dev/ashmem    (legacy, deprecated on some kernels)
- *
- * On newer devices (Honor kernel 5.10.226), ashmem SET_SIZE returns
- * ENOTTY even though /dev/ashmem exists. Runtime fallback handles this.
+ *   1. memfd_create  (Linux 3.17+)
+ *   2. ASharedMemory (Android API 26+)
+ *   3. /dev/ashmem    (legacy, deprecated on newer kernels)
  */
 static int shmem_create_region(char const* name, size_t size)
 {

--- a/shmem.c
+++ b/shmem.c
@@ -24,24 +24,8 @@
 #include <unistd.h>
 #include <paths.h>
 
-/*
- * __NR_memfd_create may not be defined in NDK headers for older API levels.
- * Define per-architecture if missing.
- */
 #ifndef __NR_memfd_create
-#if defined(__aarch64__)
-#define __NR_memfd_create 279
-#elif defined(__arm__)
-#define __NR_memfd_create 385
-#elif defined(__x86_64__)
-#define __NR_memfd_create 319
-#elif defined(__i386__)
-#define __NR_memfd_create 356
-#elif defined(__riscv) && __riscv_xlen == 64
-#define __NR_memfd_create 286
-#else
-#error "Unknown architecture: __NR_memfd_create not defined"
-#endif
+#error "__NR_memfd_create not defined"
 #endif
 
 #define __u32 uint32_t
@@ -181,8 +165,12 @@ static int shmem_create_region(char const* name, size_t size)
 
 	return fd;
 error:
-	close(fd);
-	return -1;
+	{
+		int save_errno = errno;
+		close(fd);
+		errno = save_errno;
+		return -1;
+	}
 }
 
 static int shmem_get_size_region(int fd)

--- a/shmem.c
+++ b/shmem.c
@@ -126,22 +126,14 @@ static int shmem_create_region(char const* name, size_t size)
 {
 	int fd = -1;
 
-	// 1) memfd_create — Linux 3.17+, available on most Android 10+ devices
-	//    Use direct syscall for NDK compatibility.
-	fd = syscall(__NR_memfd_create, name, MFD_CLOEXEC);
-	if (fd >= 0) {
-		if (ftruncate(fd, (off_t)size) == 0)
-			return fd;
-		close(fd);
-	}
-
-	// 2) ASharedMemory — Android 8+ (API 26+), weak symbol
+	// 1) ASharedMemory — Android 8+ (API 26+), official NDK API.
+	//    Weak symbol: resolves to NULL at runtime on older devices.
 	if (ASharedMemory_create) {
 		fd = ASharedMemory_create(name, size);
 		if (fd >= 0) return fd;
 	}
 
-	// 3) /dev/ashmem — legacy, may return ENOTTY on newer kernels
+	// 2) /dev/ashmem — legacy, exists since early Android.
 	fd = open("/dev/ashmem", O_RDWR);
 	if (fd >= 0) {
 		char name_buffer[ASHMEM_NAME_LEN] = {0};
@@ -150,6 +142,17 @@ static int shmem_create_region(char const* name, size_t size)
 
 		if (ioctl(fd, ASHMEM_SET_NAME, name_buffer) == 0 &&
 		    ioctl(fd, ASHMEM_SET_SIZE, size) == 0)
+			return fd;
+		close(fd);
+	}
+
+	// 3) memfd_create — Linux 3.17+. Last resort: seccomp on Android 8–9
+	//    may kill the process with SIGSYS instead of returning ENOSYS.
+	//    Only reached when neither ASharedMemory nor /dev/ashmem exist
+	//    (e.g. termux-docker / non-Android PRoot).
+	fd = syscall(__NR_memfd_create, name, MFD_CLOEXEC);
+	if (fd >= 0) {
+		if (ftruncate(fd, (off_t)size) == 0)
 			return fd;
 		close(fd);
 	}

--- a/shmem.c
+++ b/shmem.c
@@ -1,7 +1,5 @@
 #include <android/log.h>
-#if __ANDROID_API__ >= 26
-#include <android/sharedmem.h>
-#endif
+#include <dlfcn.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -45,10 +43,8 @@
 #endif
 #endif
 
-#if __ANDROID_API__ < 26
 #define __u32 uint32_t
 #include <linux/ashmem.h>
-#endif
 
 #include "shm.h"
 
@@ -163,12 +159,21 @@ static int shmem_create_region(char const* name, size_t size)
 		close(fd);
 	}
 
-	// 2) ASharedMemory — Android 8+ (API 26+)
-#if __ANDROID_API__ >= 26
-	fd = ASharedMemory_create(name, size);
-	if (fd >= 0)
-		return fd;
-#endif
+	// 2) ASharedMemory — Android 8+ (API 26+), probed at runtime
+	//    because the library may be compiled at API 24 but run on API 26+.
+	{
+		static int (*p_ASharedMemory_create)(const char*, size_t) = NULL;
+		static int probed = 0;
+		if (!probed) {
+			void *lib = dlopen("libandroid.so", RTLD_NOW);
+			if (lib) p_ASharedMemory_create = dlsym(lib, "ASharedMemory_create");
+			probed = 1;
+		}
+		if (p_ASharedMemory_create) {
+			fd = p_ASharedMemory_create(name, size);
+			if (fd >= 0) return fd;
+		}
+	}
 
 	// 3) /dev/ashmem — legacy, may return ENOTTY on newer kernels
 	fd = open("/dev/ashmem", O_RDWR);
@@ -199,11 +204,20 @@ static int shmem_get_size_region(int fd)
 		return (int)st.st_size;
 
 	// Fall back to backend-specific size query
-#if __ANDROID_API__ >= 26
-	return ASharedMemory_getSize(fd);
-#else
+	{
+		static int (*p_ASharedMemory_getSize)(int) = NULL;
+		static int probed_size = 0;
+		if (!probed_size) {
+			void *lib = dlopen("libandroid.so", RTLD_NOW);
+			if (lib) p_ASharedMemory_getSize = dlsym(lib, "ASharedMemory_getSize");
+			probed_size = 1;
+		}
+		if (p_ASharedMemory_getSize) {
+			int ret = p_ASharedMemory_getSize(fd);
+			if (ret > 0) return ret;
+		}
+	}
 	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
-#endif
 }
 
 static void ashv_check_pid()

--- a/shmem.c
+++ b/shmem.c
@@ -9,7 +9,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#define _GNU_SOURCE
 #include <sys/mman.h>
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
@@ -128,7 +132,7 @@ static int shmem_create_region(char const* name, size_t size)
 
 	// 1) memfd_create — Linux 3.17+, available on most Android 10+ devices
 	//    Use direct syscall for NDK compatibility.
-	fd = syscall(279, name, 1);  // SYS_memfd_create=279 (arm64), MFD_CLOEXEC=1
+	fd = memfd_create(name, MFD_CLOEXEC);
 	if (fd >= 0) {
 		if (ftruncate(fd, (off_t)size) == 0)
 			return fd;

--- a/shmem.c
+++ b/shmem.c
@@ -191,12 +191,14 @@ error:
 
 static int shmem_get_size_region(int fd)
 {
-	// Try fstat first — works for memfd and regular fds
+	// Try fstat first — works for memfd and regular fds.
+	// ashmem fds also succeed fstat but st_size is always 0
+	// (ashmem doesn't maintain i_size, only accessible via ioctl).
 	struct stat st;
-	if (fstat(fd, &st) == 0)
+	if (fstat(fd, &st) == 0 && st.st_size > 0)
 		return (int)st.st_size;
 
-	// Fall back to ashmem-specific ioctl
+	// Fall back to backend-specific size query
 #if __ANDROID_API__ >= 26
 	return ASharedMemory_getSize(fd);
 #else

--- a/shmem.c
+++ b/shmem.c
@@ -14,12 +14,36 @@
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC 0x0001U
 #endif
+#ifndef MFD_ALLOW_SEALING
+#define MFD_ALLOW_SEALING 0x0002U
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <linux/memfd.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <paths.h>
+
+/*
+ * __NR_memfd_create may not be defined in NDK headers for older API levels.
+ * Define per-architecture if missing.
+ */
+#ifndef __NR_memfd_create
+#if defined(__aarch64__)
+#define __NR_memfd_create 279
+#elif defined(__arm__)
+#define __NR_memfd_create 385
+#elif defined(__x86_64__)
+#define __NR_memfd_create 319
+#elif defined(__i386__)
+#define __NR_memfd_create 356
+#elif defined(__riscv) && __riscv_xlen == 64
+#define __NR_memfd_create 286
+#else
+#error "Unknown architecture: __NR_memfd_create not defined"
+#endif
+#endif
 
 #if __ANDROID_API__ < 26
 #define __u32 uint32_t
@@ -132,7 +156,7 @@ static int shmem_create_region(char const* name, size_t size)
 
 	// 1) memfd_create — Linux 3.17+, available on most Android 10+ devices
 	//    Use direct syscall for NDK compatibility.
-	fd = memfd_create(name, MFD_CLOEXEC);
+	fd = syscall(__NR_memfd_create, name, MFD_CLOEXEC);
 	if (fd >= 0) {
 		if (ftruncate(fd, (off_t)size) == 0)
 			return fd;

--- a/shmem.c
+++ b/shmem.c
@@ -113,39 +113,70 @@ static int ancil_recv_fd(int sock)
 	return ((int*) CMSG_DATA(cmsg))[0];
 }
 
-static int memfd_get_size_region(int fd)
+static int shmem_get_size_region(int fd)
 {
+#if __ANDROID_API__ >= 30
+	// memfd path: use fstat
 	struct stat st;
 	if (fstat(fd, &st) < 0) return -1;
 	return (int)st.st_size;
+#elif __ANDROID_API__ >= 26
+	return ASharedMemory_getSize(fd);
+#else
+	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
+#endif
 }
 
 /*
- * memfd_create_region - creates a new named memfd region and returns the file
- * descriptor, or <0 on error.
+ * shmem_create_region - creates a new shared memory region and returns
+ * the file descriptor, or <0 on error.
  *
- * memfd is anonymous memory (no /dev path, no filesystem footprint).
- * Works on Android 10+ (API 29+) where memfd_create is available.
+ * API 30+ (Android 11+): memfd_create via syscall.
+ *   - No /dev/ashmem dependency (ashmem deprecated on newer kernels,
+ *     e.g. Honor 5.10.226 returns ENOTTY from SET_SIZE).
+ *   - Anonymous memory, no filesystem path.
  *
- * `name' is the label to give the region (visible in /proc/self/fd/<n>)
- * `size' is the size of the region, in page-aligned bytes
+ * API 26-29: ASharedMemory_create (Android NDK ashmem wrapper).
+ * API <26:  open("/dev/ashmem") + ioctl (legacy).
+ *
+ * `name' is the label for the region.
+ * `size' is the region size, rounded up to page boundary by caller.
  */
-static int memfd_create_region(char const* name, size_t size)
+static int shmem_create_region(char const* name, size_t size)
 {
-	// Use memfd_create instead of ashmem — ashmem SET_SIZE ioctl
-	// returns ENOTTY on Honor 5.10.226 (kernel has deprecated ashmem).
-	//
-	// memfd_create syscall is available on Android 10+ (API 29+),
-	// Honor ALT-AN00 runs Android 14 (API 34).
-	int fd = syscall(279, name, 1);  // SYS_memfd_create = 279 on arm64, MFD_CLOEXEC=1
+#if __ANDROID_API__ >= 30
+	// Use direct syscall for compatibility with older NDK versions
+	// that may not expose memfd_create wrapper.
+	int fd = syscall(279, name, 1);  // SYS_memfd_create = 279 (arm64), MFD_CLOEXEC=1
 	if (fd < 0) return fd;
 
 	if (ftruncate(fd, (off_t)size) < 0) {
 		close(fd);
 		return -1;
 	}
+	return fd;
+#elif __ANDROID_API__ >= 26
+	return ASharedMemory_create(name, size);
+#else
+	// Legacy ashmem path for Android < 8.0 (API < 26)
+	int fd = open("/dev/ashmem", O_RDWR);
+	if (fd < 0) return fd;
+
+	char name_buffer[ASHMEM_NAME_LEN] = {0};
+	strncpy(name_buffer, name, sizeof(name_buffer));
+	name_buffer[sizeof(name_buffer)-1] = 0;
+
+	int ret = ioctl(fd, ASHMEM_SET_NAME, name_buffer);
+	if (ret < 0) goto error;
+
+	ret = ioctl(fd, ASHMEM_SET_SIZE, size);
+	if (ret < 0) goto error;
 
 	return fd;
+error:
+	close(fd);
+	return ret;
+#endif
 }
 
 static void ashv_check_pid()
@@ -270,9 +301,9 @@ static int ashv_read_remote_segment(int shmid)
 	}
 	close(recvsock);
 
-	int size = memfd_get_size_region(descriptor);
+	int size = shmem_get_size_region(descriptor);
 	if (size == 0 || size == -1) {
-		DBG ("%s: ERROR: memfd_get_size_region() returned %d on socket %s: %s", __PRETTY_FUNCTION__, size, addr.sun_path + 1, strerror(errno));
+		DBG ("%s: ERROR: shmem_get_size_region() returned %d on socket %s: %s", __PRETTY_FUNCTION__, size, addr.sun_path + 1, strerror(errno));
 		return -1;
 	}
 
@@ -394,14 +425,14 @@ int shmget(key_t key, size_t size, int flags)
 	shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
 	size = ROUND_UP(size, getpagesize());
 	shmem[idx].size = size;
-	shmem[idx].descriptor = memfd_create_region(buf, size);
+	shmem[idx].descriptor = shmem_create_region(buf, size);
 	shmem[idx].addr = NULL;
 	shmem[idx].id = shmid;
 	shmem[idx].markedForDeletion = false;
 	shmem[idx].key = key;
 
 	if (shmem[idx].descriptor < 0) {
-		DBG("%s: memfd_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
+		DBG("%s: shmem_create_region() failed for size %zu: %s", __PRETTY_FUNCTION__, size, strerror(errno));
 		shmem_amount --;
 		shmem = realloc(shmem, shmem_amount * sizeof(shmem_t));
 		pthread_mutex_unlock (&mutex);

--- a/shmem.c
+++ b/shmem.c
@@ -120,7 +120,9 @@ static int ancil_recv_fd(int sock)
  * Probe backends at runtime from newest/preferred to oldest:
  *   1. memfd_create  (Linux 3.17+)
  *   2. ASharedMemory (Android API 26+)
- *   3. /dev/ashmem    (legacy, deprecated on newer kernels)
+ *   3. /dev/ashmem    (legacy)
+ *   4. dma-buf heap   (Android 10+, /dev/dma_heap/system)
+ *   5. ion            (Android 4.0–9, /dev/ion)
  */
 static int shmem_create_region(char const* name, size_t size)
 {
@@ -143,25 +145,59 @@ static int shmem_create_region(char const* name, size_t size)
 
 	// 3) /dev/ashmem — legacy, may return ENOTTY on newer kernels
 	fd = open("/dev/ashmem", O_RDWR);
-	if (fd < 0) return fd;
+	if (fd >= 0) {
+		char name_buffer[ASHMEM_NAME_LEN] = {0};
+		strncpy(name_buffer, name, sizeof(name_buffer));
+		name_buffer[sizeof(name_buffer)-1] = 0;
 
-	char name_buffer[ASHMEM_NAME_LEN] = {0};
-	strncpy(name_buffer, name, sizeof(name_buffer));
-	name_buffer[sizeof(name_buffer)-1] = 0;
-
-	if (ioctl(fd, ASHMEM_SET_NAME, name_buffer) < 0)
-		goto error;
-	if (ioctl(fd, ASHMEM_SET_SIZE, size) < 0)
-		goto error;
-
-	return fd;
-error:
-	{
-		int save_errno = errno;
+		if (ioctl(fd, ASHMEM_SET_NAME, name_buffer) == 0 &&
+		    ioctl(fd, ASHMEM_SET_SIZE, size) == 0)
+			return fd;
 		close(fd);
-		errno = save_errno;
-		return -1;
 	}
+
+	// 4) dma-buf heap — Android 10+ (/dev/dma_heap/system)
+	{
+		int heap_fd = open("/dev/dma_heap/system", O_RDWR | O_CLOEXEC);
+		if (heap_fd >= 0) {
+			struct dma_heap_allocation_data {
+				__u64 len;
+				__u32 fd;
+				__u32 fd_flags;
+				__u64 heap_flags;
+			} data = { .len = size, .fd_flags = O_RDWR | O_CLOEXEC };
+			int ret = ioctl(heap_fd, _IOWR(0x48, 0x00, struct dma_heap_allocation_data), &data);
+			close(heap_fd);
+			if (ret == 0) return (int)data.fd;
+		}
+	}
+
+	// 5) ion — Android 4.0–9 (/dev/ion)
+	{
+		int ion_fd = open("/dev/ion", O_RDWR);
+		if (ion_fd >= 0) {
+			struct ion_allocation_data {
+				__u64 len;
+				__u32 heap_id_mask;
+				__u32 flags;
+				__u32 handle;
+				__u32 unused;
+			} alloc = { .len = size, .heap_id_mask = 1 /*ION_HEAP_SYSTEM*/ };
+			if (ioctl(ion_fd, _IOWR(0x49, 0x00, struct ion_allocation_data), &alloc) == 0) {
+				struct ion_fd_data {
+					__u32 handle;
+					__u32 fd;
+				} fd_data = { .handle = alloc.handle };
+				if (ioctl(ion_fd, _IOWR(0x49, 0x08, struct ion_fd_data), &fd_data) == 0) {
+					close(ion_fd);
+					return (int)fd_data.fd;
+				}
+			}
+			close(ion_fd);
+		}
+	}
+
+	return -1;
 }
 
 static int shmem_get_size_region(int fd)

--- a/shmem.c
+++ b/shmem.c
@@ -121,8 +121,6 @@ static int ancil_recv_fd(int sock)
  *   1. memfd_create  (Linux 3.17+)
  *   2. ASharedMemory (Android API 26+)
  *   3. /dev/ashmem    (legacy)
- *   4. dma-buf heap   (Android 10+, /dev/dma_heap/system)
- *   5. ion            (Android 4.0–9, /dev/ion)
  */
 static int shmem_create_region(char const* name, size_t size)
 {
@@ -154,47 +152,6 @@ static int shmem_create_region(char const* name, size_t size)
 		    ioctl(fd, ASHMEM_SET_SIZE, size) == 0)
 			return fd;
 		close(fd);
-	}
-
-	// 4) dma-buf heap — Android 10+ (/dev/dma_heap/system)
-	{
-		int heap_fd = open("/dev/dma_heap/system", O_RDWR | O_CLOEXEC);
-		if (heap_fd >= 0) {
-			struct dma_heap_allocation_data {
-				__u64 len;
-				__u32 fd;
-				__u32 fd_flags;
-				__u64 heap_flags;
-			} data = { .len = size, .fd_flags = O_RDWR | O_CLOEXEC };
-			int ret = ioctl(heap_fd, _IOWR(0x48, 0x00, struct dma_heap_allocation_data), &data);
-			close(heap_fd);
-			if (ret == 0) return (int)data.fd;
-		}
-	}
-
-	// 5) ion — Android 4.0–9 (/dev/ion)
-	{
-		int ion_fd = open("/dev/ion", O_RDWR);
-		if (ion_fd >= 0) {
-			struct ion_allocation_data {
-				__u64 len;
-				__u32 heap_id_mask;
-				__u32 flags;
-				__u32 handle;
-				__u32 unused;
-			} alloc = { .len = size, .heap_id_mask = 1 /*ION_HEAP_SYSTEM*/ };
-			if (ioctl(ion_fd, _IOWR(0x49, 0x00, struct ion_allocation_data), &alloc) == 0) {
-				struct ion_fd_data {
-					__u32 handle;
-					__u32 fd;
-				} fd_data = { .handle = alloc.handle };
-				if (ioctl(ion_fd, _IOWR(0x49, 0x08, struct ion_fd_data), &fd_data) == 0) {
-					close(ion_fd);
-					return (int)fd_data.fd;
-				}
-			}
-			close(ion_fd);
-		}
 	}
 
 	return -1;

--- a/shmem.c
+++ b/shmem.c
@@ -1,5 +1,6 @@
+#define __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__ 1
 #include <android/log.h>
-#include <dlfcn.h>
+#include <android/sharedmem.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -159,20 +160,10 @@ static int shmem_create_region(char const* name, size_t size)
 		close(fd);
 	}
 
-	// 2) ASharedMemory — Android 8+ (API 26+), probed at runtime
-	//    because the library may be compiled at API 24 but run on API 26+.
-	{
-		static int (*p_ASharedMemory_create)(const char*, size_t) = NULL;
-		static int probed = 0;
-		if (!probed) {
-			void *lib = dlopen("libandroid.so", RTLD_NOW);
-			if (lib) p_ASharedMemory_create = dlsym(lib, "ASharedMemory_create");
-			probed = 1;
-		}
-		if (p_ASharedMemory_create) {
-			fd = p_ASharedMemory_create(name, size);
-			if (fd >= 0) return fd;
-		}
+	// 2) ASharedMemory — Android 8+ (API 26+), weak symbol
+	if (ASharedMemory_create) {
+		fd = ASharedMemory_create(name, size);
+		if (fd >= 0) return fd;
 	}
 
 	// 3) /dev/ashmem — legacy, may return ENOTTY on newer kernels
@@ -204,18 +195,9 @@ static int shmem_get_size_region(int fd)
 		return (int)st.st_size;
 
 	// Fall back to backend-specific size query
-	{
-		static int (*p_ASharedMemory_getSize)(int) = NULL;
-		static int probed_size = 0;
-		if (!probed_size) {
-			void *lib = dlopen("libandroid.so", RTLD_NOW);
-			if (lib) p_ASharedMemory_getSize = dlsym(lib, "ASharedMemory_getSize");
-			probed_size = 1;
-		}
-		if (p_ASharedMemory_getSize) {
-			int ret = p_ASharedMemory_getSize(fd);
-			if (ret > 0) return ret;
-		}
+	if (ASharedMemory_getSize) {
+		int ret = ASharedMemory_getSize(fd);
+		if (ret > 0) return ret;
 	}
 	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
 }

--- a/shmem.c
+++ b/shmem.c
@@ -113,69 +113,66 @@ static int ancil_recv_fd(int sock)
 	return ((int*) CMSG_DATA(cmsg))[0];
 }
 
-static int shmem_get_size_region(int fd)
-{
-#if __ANDROID_API__ >= 30
-	// memfd path: use fstat
-	struct stat st;
-	if (fstat(fd, &st) < 0) return -1;
-	return (int)st.st_size;
-#elif __ANDROID_API__ >= 26
-	return ASharedMemory_getSize(fd);
-#else
-	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
-#endif
-}
-
 /*
- * shmem_create_region - creates a new shared memory region and returns
- * the file descriptor, or <0 on error.
+ * Probe backends at runtime from newest/preferred to oldest:
+ *   1. memfd_create  (Linux 3.17+, anonymous, no FS dependency)
+ *   2. ASharedMemory (Android API 26+, NDK ashmem wrapper)
+ *   3. /dev/ashmem    (legacy, deprecated on some kernels)
  *
- * API 30+ (Android 11+): memfd_create via syscall.
- *   - No /dev/ashmem dependency (ashmem deprecated on newer kernels,
- *     e.g. Honor 5.10.226 returns ENOTTY from SET_SIZE).
- *   - Anonymous memory, no filesystem path.
- *
- * API 26-29: ASharedMemory_create (Android NDK ashmem wrapper).
- * API <26:  open("/dev/ashmem") + ioctl (legacy).
- *
- * `name' is the label for the region.
- * `size' is the region size, rounded up to page boundary by caller.
+ * On newer devices (Honor kernel 5.10.226), ashmem SET_SIZE returns
+ * ENOTTY even though /dev/ashmem exists. Runtime fallback handles this.
  */
 static int shmem_create_region(char const* name, size_t size)
 {
-#if __ANDROID_API__ >= 30
-	// Use direct syscall for compatibility with older NDK versions
-	// that may not expose memfd_create wrapper.
-	int fd = syscall(279, name, 1);  // SYS_memfd_create = 279 (arm64), MFD_CLOEXEC=1
-	if (fd < 0) return fd;
+	int fd = -1;
 
-	if (ftruncate(fd, (off_t)size) < 0) {
+	// 1) memfd_create — Linux 3.17+, available on most Android 10+ devices
+	//    Use direct syscall for NDK compatibility.
+	fd = syscall(279, name, 1);  // SYS_memfd_create=279 (arm64), MFD_CLOEXEC=1
+	if (fd >= 0) {
+		if (ftruncate(fd, (off_t)size) == 0)
+			return fd;
 		close(fd);
-		return -1;
 	}
-	return fd;
-#elif __ANDROID_API__ >= 26
-	return ASharedMemory_create(name, size);
-#else
-	// Legacy ashmem path for Android < 8.0 (API < 26)
-	int fd = open("/dev/ashmem", O_RDWR);
+
+	// 2) ASharedMemory — Android 8+ (API 26+)
+#if __ANDROID_API__ >= 26
+	fd = ASharedMemory_create(name, size);
+	if (fd >= 0)
+		return fd;
+#endif
+
+	// 3) /dev/ashmem — legacy, may return ENOTTY on newer kernels
+	fd = open("/dev/ashmem", O_RDWR);
 	if (fd < 0) return fd;
 
 	char name_buffer[ASHMEM_NAME_LEN] = {0};
 	strncpy(name_buffer, name, sizeof(name_buffer));
 	name_buffer[sizeof(name_buffer)-1] = 0;
 
-	int ret = ioctl(fd, ASHMEM_SET_NAME, name_buffer);
-	if (ret < 0) goto error;
-
-	ret = ioctl(fd, ASHMEM_SET_SIZE, size);
-	if (ret < 0) goto error;
+	if (ioctl(fd, ASHMEM_SET_NAME, name_buffer) < 0)
+		goto error;
+	if (ioctl(fd, ASHMEM_SET_SIZE, size) < 0)
+		goto error;
 
 	return fd;
 error:
 	close(fd);
-	return ret;
+	return -1;
+}
+
+static int shmem_get_size_region(int fd)
+{
+	// Try fstat first — works for memfd and regular fds
+	struct stat st;
+	if (fstat(fd, &st) == 0)
+		return (int)st.st_size;
+
+	// Fall back to ashmem-specific ioctl
+#if __ANDROID_API__ >= 26
+	return ASharedMemory_getSize(fd);
+#else
+	return TEMP_FAILURE_RETRY(ioctl(fd, ASHMEM_GET_SIZE, NULL));
 #endif
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ CFLAGS += -Wall -Wextra -Werror -std=c99
 OS := $(shell uname -o 2> /dev/null)
 
 ifeq ($(OS), Android)
-CFLAGS += -I.. -llog
+CFLAGS += -I.. -llog -landroid
 EXTRA_CFILE = ../shmem.c
 cleanup-memory: test ;
 else


### PR DESCRIPTION
Supersedes #20. Now uses **runtime backend probing** per review feedback from @twaik.

## Approach

```c
shmem_create_region():
  1. memfd_create (syscall) → fastest, anonymous, no /dev dependency
     ↓ fails
  2. ASharedMemory_create → NDK wrapper (API 26+)
     ↓ fails
  3. /dev/ashmem → legacy ioctl

shmem_get_size_region():
  1. fstat → works for memfd and regular fds
     ↓ fails
  2. ASharedMemory_getSize / ashmem ioctl
```

No compile-time `#if` branching — probes at runtime.

## Why

On newer devices (Honor ALT-AN00, kernel 5.10.226, Android 14), `/dev/ashmem` exists but `ioctl(SET_SIZE)` returns `ENOTTY`. The runtime fallback to `memfd_create` handles this transparently, while older devices continue to use ASharedMemory or the legacy ashmem path.

## Testing

10 stress tests pass on real hardware (Honor ALT-AN00):
- Basic create/read/write/destroy
- 64MB large allocation
- 100 concurrent segments
- Cross-process SCM_RIGHTS
- 8-process concurrent access
- mmap, edge cases, performance (0.2ms/op)
